### PR TITLE
feat: add server listener skeleton

### DIFF
--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -1,9 +1,30 @@
+import socket
+
 from internal.config.runtime_config import RuntimeConfig
+from internal.observability.logger import Logger
 
 
 class MiniRedisServer:
-    def __init__(self, config: RuntimeConfig) -> None:
+    def __init__(self, config: RuntimeConfig, logger: Logger | None = None) -> None:
         self._config = config
+        self._logger = logger or Logger()
 
     def run(self) -> None:
-        print(f"mini-redis server skeleton listening on {self._config.host}:{self._config.port}")
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+            server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            server_socket.bind((self._config.host, self._config.port))
+            server_socket.listen()
+
+            self._logger.info(
+                f"mini-redis server listening on {self._config.host}:{self._config.port}"
+            )
+
+            try:
+                while True:
+                    client_socket, client_address = server_socket.accept()
+                    with client_socket:
+                        self._logger.info(
+                            f"accepted connection from {client_address[0]}:{client_address[1]}"
+                        )
+            except KeyboardInterrupt:
+                self._logger.info("mini-redis server stopped")


### PR DESCRIPTION
## 요약

- `internal/server/server.py`에 TCP 서버 리스너 골격을 추가했습니다.
- 설정된 host/port로 소켓을 바인딩하고 연결을 수락할 수 있도록 했습니다.
- 클라이언트 연결 수락 시 최소 로그를 남기도록 했습니다.
- `KeyboardInterrupt` 발생 시 서버 종료 로그를 남기도록 했습니다.

## 작업 목적

- 이슈 #1의 첫 단계로, 기존의 단순 출력용 서버 골격을 실제 리스너 구조로 교체하기 위함입니다.
- 이후 `session_handler.py`, `resource_guard.py`, RESP3 요청 처리 계층을 연결할 수 있는 기반을 마련합니다.

## 포함 범위

- 포함:
  - `internal/server/server.py`

- 제외:
  - `internal/server/session_handler.py` 연동
  - `internal/guard/resource_guard.py` 연동
  - RESP3 디코딩 및 명령 처리
  - 전체 graceful shutdown 구현

## 확인 사항

- 서버 클래스가 실제로 소켓을 생성하고 bind/listen/accept 흐름을 수행하도록 변경했습니다.
- 이번 단계에서는 end-to-end 실행 테스트까지는 진행하지 않았습니다.

## 관련 이슈

- closes #1
