### PR TITLE
feat: add session handler skeleton

### DIFF
--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -2,6 +2,10 @@ import socket
 
 from internal.config.runtime_config import RuntimeConfig
 from internal.observability.logger import Logger
+from internal.protocol.resp.request_decoder import RespRequestDecoder
+from internal.protocol.resp.response_encoder import RespResponseEncoder
+from internal.server.session_handler import SessionHandler
+from internal.service.command_service import CommandService
 
 
 class MiniRedisServer:
@@ -26,5 +30,14 @@ class MiniRedisServer:
                         self._logger.info(
                             f"accepted connection from {client_address[0]}:{client_address[1]}"
                         )
+                        handler = SessionHandler(
+                            client_socket=client_socket,
+                            request_decoder=RespRequestDecoder(),
+                            command_service=CommandService(),
+                            response_encoder=RespResponseEncoder(),
+                            logger=self._logger,
+                            read_size=self._config.max_request_size_bytes,
+                        )
+                        handler.handle()
             except KeyboardInterrupt:
                 self._logger.info("mini-redis server stopped")

--- a/internal/server/session_handler.py
+++ b/internal/server/session_handler.py
@@ -1,3 +1,46 @@
+import socket
+
+from internal.observability.logger import Logger
+from internal.protocol.resp.request_decoder import RespRequestDecoder
+from internal.protocol.resp.response_encoder import RespResponseEncoder
+from internal.service.command_service import CommandService
+
+
 class SessionHandler:
+    def __init__(
+        self,
+        client_socket: socket.socket,
+        request_decoder: RespRequestDecoder,
+        command_service: CommandService,
+        response_encoder: RespResponseEncoder,
+        logger: Logger | None = None,
+        read_size: int = 4096,
+    ) -> None:
+        self._client_socket = client_socket
+        self._request_decoder = request_decoder
+        self._command_service = command_service
+        self._response_encoder = response_encoder
+        self._logger = logger or Logger()
+        self._read_size = read_size
+
     def handle(self) -> None:
-        raise NotImplementedError("Session handling is not implemented yet")
+        try:
+            request_bytes = self._read_request()
+            if not request_bytes:
+                return
+
+            response = self._process_request(request_bytes)
+            self._write_response(response)
+        except Exception as error:
+            self._logger.error(f"session handling failed: {error}")
+
+    def _read_request(self) -> bytes:
+        return self._client_socket.recv(self._read_size)
+
+    def _process_request(self, request_bytes: bytes) -> bytes:
+        decoded_request = self._request_decoder.decode(request_bytes)
+        service_result = self._command_service.execute(decoded_request)  # type: ignore[arg-type]
+        return self._response_encoder.encode(service_result)
+
+    def _write_response(self, response: bytes) -> None:
+        self._client_socket.sendall(response)


### PR DESCRIPTION
## 요약

- `session_handler.py`에 요청 읽기/처리/응답 쓰기 골격을 추가했습니다.
- 요청 단위 예외 격리와 최소 로그 처리를 넣었습니다.
- `server.py`에서 연결 수락 후 `SessionHandler`를 실제로 호출하도록 연결했습니다.

## 범위

- `internal/server/session_handler.py`
- `internal/server/server.py`

## 참고

- RESP3 디코더, 인코더, 서비스 로직은 아직 placeholder 상태입니다.
- 이번 PR은 세션 처리 조립 구조를 만드는 데 초점을 맞췄습니다.

## 관련 이슈

- closes #2