### PR TITLE
Feat/3 3 resource guard

### DIFF
--- a/internal/guard/resource_guard.py
+++ b/internal/guard/resource_guard.py
@@ -5,5 +5,8 @@ class ResourceGuard:
     def __init__(self, limits: ResourceLimits) -> None:
         self._limits = limits
 
-    def validate_request_size(self, size_bytes: int) -> bool:
+    def is_request_size_allowed(self, size_bytes: int) -> bool:
         return size_bytes <= self._limits.max_request_size_bytes
+
+    def is_connection_allowed(self, active_connections: int) -> bool:
+        return active_connections < self._limits.max_connections

--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -1,6 +1,8 @@
 import socket
 
 from internal.config.runtime_config import RuntimeConfig
+from internal.guard.limits import ResourceLimits
+from internal.guard.resource_guard import ResourceGuard
 from internal.observability.logger import Logger
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
@@ -12,6 +14,16 @@ class MiniRedisServer:
     def __init__(self, config: RuntimeConfig, logger: Logger | None = None) -> None:
         self._config = config
         self._logger = logger or Logger()
+        self._resource_guard = ResourceGuard(
+            ResourceLimits(
+                max_connections=self._config.max_connections,
+                max_request_size_bytes=self._config.max_request_size_bytes,
+                max_array_items=self._config.max_array_items,
+                max_resp_depth=self._config.max_resp_depth,
+                max_blob_size_bytes=self._config.max_blob_size_bytes,
+            )
+        )
+        self._active_connections = 0
 
     def run(self) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
@@ -27,6 +39,15 @@ class MiniRedisServer:
                 while True:
                     client_socket, client_address = server_socket.accept()
                     with client_socket:
+                        if not self._resource_guard.is_connection_allowed(
+                            self._active_connections
+                        ):
+                            self._logger.error(
+                                "connection limit exceeded; closing client connection"
+                            )
+                            continue
+
+                        self._active_connections += 1
                         self._logger.info(
                             f"accepted connection from {client_address[0]}:{client_address[1]}"
                         )
@@ -35,9 +56,13 @@ class MiniRedisServer:
                             request_decoder=RespRequestDecoder(),
                             command_service=CommandService(),
                             response_encoder=RespResponseEncoder(),
+                            resource_guard=self._resource_guard,
                             logger=self._logger,
                             read_size=self._config.max_request_size_bytes,
                         )
-                        handler.handle()
+                        try:
+                            handler.handle()
+                        finally:
+                            self._active_connections -= 1
             except KeyboardInterrupt:
                 self._logger.info("mini-redis server stopped")

--- a/internal/server/session_handler.py
+++ b/internal/server/session_handler.py
@@ -1,6 +1,7 @@
 import socket
 
 from internal.observability.logger import Logger
+from internal.guard.resource_guard import ResourceGuard
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.service.command_service import CommandService
@@ -13,6 +14,7 @@ class SessionHandler:
         request_decoder: RespRequestDecoder,
         command_service: CommandService,
         response_encoder: RespResponseEncoder,
+        resource_guard: ResourceGuard,
         logger: Logger | None = None,
         read_size: int = 4096,
     ) -> None:
@@ -20,6 +22,7 @@ class SessionHandler:
         self._request_decoder = request_decoder
         self._command_service = command_service
         self._response_encoder = response_encoder
+        self._resource_guard = resource_guard
         self._logger = logger or Logger()
         self._read_size = read_size
 
@@ -27,6 +30,11 @@ class SessionHandler:
         try:
             request_bytes = self._read_request()
             if not request_bytes:
+                return
+            if not self._resource_guard.is_request_size_allowed(len(request_bytes)):
+                self._logger.error(
+                    f"request size exceeded: {len(request_bytes)} bytes"
+                )
                 return
 
             response = self._process_request(request_bytes)


### PR DESCRIPTION
## 요약

- `ResourceGuard`에 연결 수/요청 크기 제한 검사를 추가했습니다.
- `SessionHandler`와 `MiniRedisServer`에 guard 호출 지점을 연결했습니다.
- 자원 보호 로직이 실제 서버 처리 경로에서 동작할 수 있는 골격을 만들었습니다.

## 범위

- `internal/guard/resource_guard.py`
- `internal/server/session_handler.py`
- `internal/server/server.py`

## 참고

- 현재는 제한 초과 시 로그 후 종료하는 최소 동작만 포함합니다.
- RESP3 오류 응답, metrics 연동, 세부 정책은 아직 포함하지 않았습니다.