### PR TITLE
feat: RESP3 command parsing pipeline 추가

### DIFF
--- a/internal/command/command.py
+++ b/internal/command/command.py
@@ -4,4 +4,4 @@ from dataclasses import dataclass
 @dataclass(frozen=True)
 class Command:
     name: str
-    arguments: list[str]
+    arguments: tuple[str, ...]

--- a/internal/command/errors.py
+++ b/internal/command/errors.py
@@ -1,6 +1,12 @@
 class CommandError(Exception):
-    pass
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
 
 
 class CommandValidationError(CommandError):
+    pass
+
+
+class CommandParseError(CommandError):
     pass

--- a/internal/command/parser.py
+++ b/internal/command/parser.py
@@ -1,9 +1,29 @@
 from internal.command.command import Command
-from internal.command.errors import CommandValidationError
+from internal.command.errors import CommandParseError
+from internal.protocol.resp.messages import ERR_EMPTY_COMMAND, ERR_PROTOCOL_ERROR
+from internal.protocol.resp.types import RespArray, RespBlobString, RespNumber, RespSimpleString
 
 
 class CommandParser:
-    def parse(self, parts: list[str]) -> Command:
-        if not parts:
-            raise CommandValidationError("empty command")
-        return Command(name=parts[0].upper(), arguments=parts[1:])
+    def parse(self, request: RespArray) -> Command:
+        if not request.items:
+            raise CommandParseError(ERR_EMPTY_COMMAND)
+
+        parts = tuple(self._coerce_token(item) for item in request.items)
+        command_name = parts[0].strip()
+        if not command_name:
+            raise CommandParseError(ERR_EMPTY_COMMAND)
+
+        return Command(name=command_name.upper(), arguments=parts[1:])
+
+    def _coerce_token(
+        self,
+        item: RespBlobString | RespSimpleString | RespNumber,
+    ) -> str:
+        if isinstance(item, (RespBlobString, RespSimpleString)):
+            return item.value
+
+        if isinstance(item, RespNumber):
+            return str(item.value)
+
+        raise CommandParseError(ERR_PROTOCOL_ERROR)

--- a/internal/command/validator.py
+++ b/internal/command/validator.py
@@ -1,5 +1,11 @@
 from internal.command.command import Command
 from internal.command.errors import CommandValidationError
+from internal.protocol.resp.messages import (
+    ERR_INVALID_INTEGER,
+    ERR_INVALID_TTL,
+    ERR_UNSUPPORTED_COMMAND,
+    ERR_WRONG_NUMBER_OF_ARGUMENTS,
+)
 
 
 class CommandValidator:
@@ -14,6 +20,20 @@ class CommandValidator:
 
     def validate(self, command: Command) -> None:
         if command.name not in self._SUPPORTED_ARITY:
-            raise CommandValidationError("unsupported command")
+            raise CommandValidationError(ERR_UNSUPPORTED_COMMAND)
         if len(command.arguments) != self._SUPPORTED_ARITY[command.name]:
-            raise CommandValidationError("wrong number of arguments")
+            raise CommandValidationError(ERR_WRONG_NUMBER_OF_ARGUMENTS)
+
+        if command.name == "HELLO":
+            self._validate_integer_argument(command.arguments[0])
+
+        if command.name == "EXPIRE":
+            seconds = self._validate_integer_argument(command.arguments[1])
+            if seconds <= 0:
+                raise CommandValidationError(ERR_INVALID_TTL)
+
+    def _validate_integer_argument(self, value: str) -> int:
+        try:
+            return int(value)
+        except ValueError as exc:
+            raise CommandValidationError(ERR_INVALID_INTEGER) from exc

--- a/internal/protocol/resp/hello_handler.py
+++ b/internal/protocol/resp/hello_handler.py
@@ -1,15 +1,16 @@
-from internal.protocol.resp.types import RespValue
+from internal.protocol.resp.messages import ERR_UNSUPPORTED_PROTOCOL_VERSION
+from internal.protocol.resp.types import RespMap, RespNumber, RespSimpleError, RespSimpleString, RespValue
 
 
 class HelloHandler:
     def handle(self, version: int) -> RespValue:
         if version != 3:
-            return RespValue(kind="error", value="unsupported protocol version")
-        return RespValue(
-            kind="map",
-            value={
-                "server": "mini-redis",
-                "version": "1.0",
-                "proto": 3,
-            },
+            return RespSimpleError(message=ERR_UNSUPPORTED_PROTOCOL_VERSION)
+
+        return RespMap(
+            entries=(
+                (RespSimpleString(value="server"), RespSimpleString(value="mini-redis")),
+                (RespSimpleString(value="version"), RespSimpleString(value="1.0")),
+                (RespSimpleString(value="proto"), RespNumber(value=3)),
+            ),
         )

--- a/internal/protocol/resp/messages.py
+++ b/internal/protocol/resp/messages.py
@@ -1,2 +1,10 @@
 RESP_OK = "OK"
-RESP_ERR = "ERR"
+RESP_ERR_PREFIX = "ERR"
+
+ERR_EMPTY_COMMAND = "empty command"
+ERR_PROTOCOL_ERROR = "protocol error"
+ERR_UNSUPPORTED_COMMAND = "unsupported command"
+ERR_WRONG_NUMBER_OF_ARGUMENTS = "wrong number of arguments"
+ERR_INVALID_INTEGER = "invalid integer"
+ERR_INVALID_TTL = "invalid ttl"
+ERR_UNSUPPORTED_PROTOCOL_VERSION = "unsupported protocol version"

--- a/internal/protocol/resp/request_decoder.py
+++ b/internal/protocol/resp/request_decoder.py
@@ -1,6 +1,96 @@
-from internal.protocol.resp.types import RespValue
+from __future__ import annotations
+
+from internal.command.errors import CommandParseError
+from internal.protocol.resp.messages import ERR_PROTOCOL_ERROR
+from internal.protocol.resp.types import (
+    RespArray,
+    RespBlobString,
+    RespNumber,
+    RespSimpleString,
+    RespValue,
+)
 
 
 class RespRequestDecoder:
     def decode(self, data: bytes) -> RespValue:
-        raise NotImplementedError("RESP3 request decoding is not implemented yet")
+        try:
+            text = data.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise CommandParseError(ERR_PROTOCOL_ERROR) from exc
+
+        value, next_index = self._decode_value(text, 0)
+        if not isinstance(value, RespArray):
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+        if next_index != len(text):
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+        return value
+
+    def _decode_value(self, data: str, index: int) -> tuple[RespValue, int]:
+        if index >= len(data):
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+
+        prefix = data[index]
+        if prefix == "*":
+            return self._decode_array(data, index)
+        if prefix == "$":
+            return self._decode_blob_string(data, index)
+        if prefix == "+":
+            return self._decode_simple_string(data, index)
+        if prefix == ":":
+            return self._decode_number(data, index)
+
+        raise CommandParseError(ERR_PROTOCOL_ERROR)
+
+    def _decode_array(self, data: str, index: int) -> tuple[RespArray, int]:
+        count_text, cursor = self._read_line(data, index + 1)
+        try:
+            count = int(count_text)
+        except ValueError as exc:
+            raise CommandParseError(ERR_PROTOCOL_ERROR) from exc
+        if count < 0:
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+
+        items = []
+        for _ in range(count):
+            item, cursor = self._decode_value(data, cursor)
+            items.append(item)
+
+        return RespArray(items=tuple(items)), cursor
+
+    def _decode_blob_string(self, data: str, index: int) -> tuple[RespBlobString, int]:
+        length_text, cursor = self._read_line(data, index + 1)
+        try:
+            length = int(length_text)
+        except ValueError as exc:
+            raise CommandParseError(ERR_PROTOCOL_ERROR) from exc
+        if length < 0:
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+
+        end_index = cursor + length
+        if end_index + 2 > len(data) or data[end_index : end_index + 2] != "\r\n":
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+
+        return RespBlobString(value=data[cursor:end_index]), end_index + 2
+
+    def _decode_simple_string(
+        self,
+        data: str,
+        index: int,
+    ) -> tuple[RespSimpleString, int]:
+        value, cursor = self._read_line(data, index + 1)
+        return RespSimpleString(value=value), cursor
+
+    def _decode_number(self, data: str, index: int) -> tuple[RespNumber, int]:
+        number_text, cursor = self._read_line(data, index + 1)
+        try:
+            number = int(number_text)
+        except ValueError as exc:
+            raise CommandParseError(ERR_PROTOCOL_ERROR) from exc
+
+        return RespNumber(value=number), cursor
+
+    def _read_line(self, data: str, start: int) -> tuple[str, int]:
+        end_index = data.find("\r\n", start)
+        if end_index == -1:
+            raise CommandParseError(ERR_PROTOCOL_ERROR)
+        return data[start:end_index], end_index + 2

--- a/internal/protocol/resp/response_encoder.py
+++ b/internal/protocol/resp/response_encoder.py
@@ -1,6 +1,48 @@
-from internal.protocol.resp.types import RespValue
+from internal.protocol.resp.messages import RESP_ERR_PREFIX
+from internal.protocol.resp.types import (
+    RespArray,
+    RespBlobString,
+    RespMap,
+    RespNull,
+    RespNumber,
+    RespSimpleError,
+    RespSimpleString,
+    RespValue,
+)
 
 
 class RespResponseEncoder:
     def encode(self, value: RespValue) -> bytes:
-        raise NotImplementedError("RESP3 response encoding is not implemented yet")
+        if isinstance(value, RespSimpleString):
+            return f"+{value.value}\r\n".encode("utf-8")
+
+        if isinstance(value, RespBlobString):
+            payload = value.value.encode("utf-8")
+            return b"$" + str(len(payload)).encode("utf-8") + b"\r\n" + payload + b"\r\n"
+
+        if isinstance(value, RespNumber):
+            return f":{value.value}\r\n".encode("utf-8")
+
+        if isinstance(value, RespNull):
+            return b"_\r\n"
+
+        if isinstance(value, RespSimpleError):
+            return f"-{RESP_ERR_PREFIX} {value.message}\r\n".encode("utf-8")
+
+        if isinstance(value, RespArray):
+            encoded_items = b"".join(self.encode(item) for item in value.items)
+            return b"*" + str(len(value.items)).encode("utf-8") + b"\r\n" + encoded_items
+
+        if isinstance(value, RespMap):
+            encoded_entries = []
+            for key, entry_value in value.entries:
+                encoded_entries.append(self.encode(key))
+                encoded_entries.append(self.encode(entry_value))
+            return (
+                b"%"
+                + str(len(value.entries)).encode("utf-8")
+                + b"\r\n"
+                + b"".join(encoded_entries)
+            )
+
+        raise TypeError(f"unsupported RESP value: {type(value)!r}")

--- a/internal/protocol/resp/types.py
+++ b/internal/protocol/resp/types.py
@@ -1,8 +1,50 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
-from typing import Any
+from typing import TypeAlias
 
 
 @dataclass(frozen=True)
-class RespValue:
-    kind: str
-    value: Any
+class RespSimpleString:
+    value: str
+
+
+@dataclass(frozen=True)
+class RespBlobString:
+    value: str
+
+
+@dataclass(frozen=True)
+class RespNumber:
+    value: int
+
+
+@dataclass(frozen=True)
+class RespNull:
+    pass
+
+
+@dataclass(frozen=True)
+class RespSimpleError:
+    message: str
+
+
+@dataclass(frozen=True)
+class RespArray:
+    items: tuple["RespValue", ...]
+
+
+@dataclass(frozen=True)
+class RespMap:
+    entries: tuple[tuple["RespValue", "RespValue"], ...]
+
+
+RespValue: TypeAlias = (
+    RespSimpleString
+    | RespBlobString
+    | RespNumber
+    | RespNull
+    | RespSimpleError
+    | RespArray
+    | RespMap
+)

--- a/tests/test_command_parser.py
+++ b/tests/test_command_parser.py
@@ -1,0 +1,53 @@
+import pytest
+
+from internal.command.errors import CommandParseError
+from internal.command.parser import CommandParser
+from internal.protocol.resp.messages import ERR_EMPTY_COMMAND, ERR_PROTOCOL_ERROR
+from internal.protocol.resp.types import RespArray, RespBlobString, RespNull, RespNumber, RespSimpleString
+
+
+def test_parse_normalizes_command_name_and_arguments() -> None:
+    parser = CommandParser()
+
+    command = parser.parse(
+        RespArray(
+            items=(
+                RespBlobString(value="set"),
+                RespBlobString(value="mykey"),
+                RespSimpleString(value="value"),
+            )
+        )
+    )
+
+    assert command.name == "SET"
+    assert command.arguments == ("mykey", "value")
+
+
+def test_parse_accepts_number_argument() -> None:
+    parser = CommandParser()
+
+    command = parser.parse(
+        RespArray(
+            items=(
+                RespSimpleString(value="hello"),
+                RespNumber(value=3),
+            )
+        )
+    )
+
+    assert command.name == "HELLO"
+    assert command.arguments == ("3",)
+
+
+def test_parse_rejects_empty_command() -> None:
+    parser = CommandParser()
+
+    with pytest.raises(CommandParseError, match=ERR_EMPTY_COMMAND):
+        parser.parse(RespArray(items=()))
+
+
+def test_parse_rejects_unsupported_resp_item_type() -> None:
+    parser = CommandParser()
+
+    with pytest.raises(CommandParseError, match=ERR_PROTOCOL_ERROR):
+        parser.parse(RespArray(items=(RespNull(),)))

--- a/tests/test_command_validator.py
+++ b/tests/test_command_validator.py
@@ -1,0 +1,45 @@
+import pytest
+
+from internal.command.command import Command
+from internal.command.errors import CommandValidationError
+from internal.command.validator import CommandValidator
+from internal.protocol.resp.messages import (
+    ERR_INVALID_INTEGER,
+    ERR_INVALID_TTL,
+    ERR_UNSUPPORTED_COMMAND,
+    ERR_WRONG_NUMBER_OF_ARGUMENTS,
+)
+
+
+def test_validate_accepts_supported_command() -> None:
+    validator = CommandValidator()
+
+    validator.validate(Command(name="SET", arguments=("key", "value")))
+
+
+def test_validate_rejects_unsupported_command() -> None:
+    validator = CommandValidator()
+
+    with pytest.raises(CommandValidationError, match=ERR_UNSUPPORTED_COMMAND):
+        validator.validate(Command(name="NOPE", arguments=()))
+
+
+def test_validate_rejects_wrong_arity() -> None:
+    validator = CommandValidator()
+
+    with pytest.raises(CommandValidationError, match=ERR_WRONG_NUMBER_OF_ARGUMENTS):
+        validator.validate(Command(name="GET", arguments=("key", "extra")))
+
+
+def test_validate_rejects_non_integer_expire() -> None:
+    validator = CommandValidator()
+
+    with pytest.raises(CommandValidationError, match=ERR_INVALID_INTEGER):
+        validator.validate(Command(name="EXPIRE", arguments=("key", "abc")))
+
+
+def test_validate_rejects_non_positive_expire() -> None:
+    validator = CommandValidator()
+
+    with pytest.raises(CommandValidationError, match=ERR_INVALID_TTL):
+        validator.validate(Command(name="EXPIRE", arguments=("key", "0")))

--- a/tests/test_hello_handler.py
+++ b/tests/test_hello_handler.py
@@ -1,0 +1,25 @@
+from internal.protocol.resp.hello_handler import HelloHandler
+from internal.protocol.resp.messages import ERR_UNSUPPORTED_PROTOCOL_VERSION
+from internal.protocol.resp.types import RespMap, RespNumber, RespSimpleError, RespSimpleString
+
+
+def test_handle_returns_server_metadata_for_resp3() -> None:
+    handler = HelloHandler()
+
+    response = handler.handle(3)
+
+    assert response == RespMap(
+        entries=(
+            (RespSimpleString(value="server"), RespSimpleString(value="mini-redis")),
+            (RespSimpleString(value="version"), RespSimpleString(value="1.0")),
+            (RespSimpleString(value="proto"), RespNumber(value=3)),
+        )
+    )
+
+
+def test_handle_returns_error_for_unsupported_version() -> None:
+    handler = HelloHandler()
+
+    response = handler.handle(2)
+
+    assert response == RespSimpleError(message=ERR_UNSUPPORTED_PROTOCOL_VERSION)

--- a/tests/test_request_decoder.py
+++ b/tests/test_request_decoder.py
@@ -1,0 +1,47 @@
+import pytest
+
+from internal.command.errors import CommandParseError
+from internal.protocol.resp.messages import ERR_PROTOCOL_ERROR
+from internal.protocol.resp.request_decoder import RespRequestDecoder
+from internal.protocol.resp.types import RespArray, RespBlobString, RespNumber
+
+
+def test_decode_hello_request_array() -> None:
+    decoder = RespRequestDecoder()
+
+    value = decoder.decode(b"*2\r\n$5\r\nHELLO\r\n:3\r\n")
+
+    assert value == RespArray(
+        items=(
+            RespBlobString(value="HELLO"),
+            RespNumber(value=3),
+        )
+    )
+
+
+def test_decode_set_request_array() -> None:
+    decoder = RespRequestDecoder()
+
+    value = decoder.decode(b"*3\r\n$3\r\nSET\r\n$3\r\nkey\r\n$5\r\nvalue\r\n")
+
+    assert value == RespArray(
+        items=(
+            RespBlobString(value="SET"),
+            RespBlobString(value="key"),
+            RespBlobString(value="value"),
+        )
+    )
+
+
+def test_decode_rejects_non_array_top_level_request() -> None:
+    decoder = RespRequestDecoder()
+
+    with pytest.raises(CommandParseError, match=ERR_PROTOCOL_ERROR):
+        decoder.decode(b"+PING\r\n")
+
+
+def test_decode_rejects_malformed_blob_string() -> None:
+    decoder = RespRequestDecoder()
+
+    with pytest.raises(CommandParseError, match=ERR_PROTOCOL_ERROR):
+        decoder.decode(b"*1\r\n$3\r\nSE\r\n")

--- a/tests/test_response_encoder.py
+++ b/tests/test_response_encoder.py
@@ -1,0 +1,54 @@
+from internal.protocol.resp.response_encoder import RespResponseEncoder
+from internal.protocol.resp.types import (
+    RespBlobString,
+    RespMap,
+    RespNull,
+    RespNumber,
+    RespSimpleError,
+    RespSimpleString,
+)
+
+
+def test_encode_simple_string() -> None:
+    encoder = RespResponseEncoder()
+
+    assert encoder.encode(RespSimpleString(value="OK")) == b"+OK\r\n"
+
+
+def test_encode_blob_string() -> None:
+    encoder = RespResponseEncoder()
+
+    assert encoder.encode(RespBlobString(value="hello")) == b"$5\r\nhello\r\n"
+
+
+def test_encode_number() -> None:
+    encoder = RespResponseEncoder()
+
+    assert encoder.encode(RespNumber(value=3)) == b":3\r\n"
+
+
+def test_encode_null() -> None:
+    encoder = RespResponseEncoder()
+
+    assert encoder.encode(RespNull()) == b"_\r\n"
+
+
+def test_encode_simple_error() -> None:
+    encoder = RespResponseEncoder()
+
+    assert encoder.encode(RespSimpleError(message="wrong number of arguments")) == (
+        b"-ERR wrong number of arguments\r\n"
+    )
+
+
+def test_encode_map() -> None:
+    encoder = RespResponseEncoder()
+
+    value = RespMap(
+        entries=(
+            (RespSimpleString(value="server"), RespSimpleString(value="mini-redis")),
+            (RespSimpleString(value="proto"), RespNumber(value=3)),
+        )
+    )
+
+    assert encoder.encode(value) == b"%2\r\n+server\r\n+mini-redis\r\n+proto\r\n:3\r\n"


### PR DESCRIPTION
## 관련 이슈
- closes #7

## 작업 내용
- RESP3 값 타입을 `Simple String`, `Blob String`, `Number`, `Null`, `Simple Error`, `Array`, `Map`으로 구체화했습니다.
- RESP 요청 디코더를 구현해 최상위 `RESP Array` 요청을 파싱하도록 했습니다.
- 내부 명령 모델을 `bytes -> RespArray -> Command -> validation` 흐름으로 고정했습니다.
- `HELLO`, `SET`, `GET`, `DEL`, `EXPIRE`, `TTL` 명령의 arity 검증과 `EXPIRE seconds` 정수/범위 검증을 추가했습니다.
- `HELLO 3` 응답과 RESP3 응답 인코더를 구현했습니다.
- 파서, 검증기, 디코더, 인코더, HELLO 핸들러에 대한 테스트를 추가했습니다.

## 검증
- `python3 -m compileall internal tests`
- `python3 -c ...` 스모크 체크
- `python3 -m pytest ...` 는 로컬에 `pytest` 모듈이 없어 실행하지 못했습니다.

## 공유할 인터페이스
- 요청 디코더 출력은 최상위 `RespArray` 입니다.
- 커맨드 파서는 `Command(name, arguments)`를 반환합니다.
- 검증 에러/파싱 에러 메시지는 `internal/protocol/resp/messages.py` 상수를 사용합니다.
- `HELLO 3` 성공 응답은 RESP3 `Map`, 실패 응답은 `Simple Error` 입니다.