### PR TITLE
feat: add basic observability hooks

### DIFF
--- a/internal/observability/metrics.py
+++ b/internal/observability/metrics.py
@@ -1,5 +1,22 @@
 class Metrics:
     def __init__(self) -> None:
         self.connections_total = 0
+        self.active_connections = 0
         self.requests_total = 0
         self.errors_total = 0
+
+    def increment_connections(self) -> None:
+        self.connections_total += 1
+
+    def increment_active_connections(self) -> None:
+        self.active_connections += 1
+
+    def decrement_active_connections(self) -> None:
+        if self.active_connections > 0:
+            self.active_connections -= 1
+
+    def increment_requests(self) -> None:
+        self.requests_total += 1
+
+    def increment_errors(self) -> None:
+        self.errors_total += 1

--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -2,6 +2,7 @@ import socket
 
 from internal.config.runtime_config import RuntimeConfig
 from internal.observability.logger import Logger
+from internal.observability.metrics import Metrics
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.server.session_handler import SessionHandler
@@ -9,9 +10,15 @@ from internal.service.command_service import CommandService
 
 
 class MiniRedisServer:
-    def __init__(self, config: RuntimeConfig, logger: Logger | None = None) -> None:
+    def __init__(
+        self,
+        config: RuntimeConfig,
+        logger: Logger | None = None,
+        metrics: Metrics | None = None,
+    ) -> None:
         self._config = config
         self._logger = logger or Logger()
+        self._metrics = metrics or Metrics()
 
     def run(self) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
@@ -27,6 +34,8 @@ class MiniRedisServer:
                 while True:
                     client_socket, client_address = server_socket.accept()
                     with client_socket:
+                        self._metrics.increment_connections()
+                        self._metrics.increment_active_connections()
                         self._logger.info(
                             f"accepted connection from {client_address[0]}:{client_address[1]}"
                         )
@@ -35,9 +44,13 @@ class MiniRedisServer:
                             request_decoder=RespRequestDecoder(),
                             command_service=CommandService(),
                             response_encoder=RespResponseEncoder(),
+                            metrics=self._metrics,
                             logger=self._logger,
                             read_size=self._config.max_request_size_bytes,
                         )
-                        handler.handle()
+                        try:
+                            handler.handle()
+                        finally:
+                            self._metrics.decrement_active_connections()
             except KeyboardInterrupt:
                 self._logger.info("mini-redis server stopped")

--- a/internal/server/session_handler.py
+++ b/internal/server/session_handler.py
@@ -1,6 +1,7 @@
 import socket
 
 from internal.observability.logger import Logger
+from internal.observability.metrics import Metrics
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.service.command_service import CommandService
@@ -13,6 +14,7 @@ class SessionHandler:
         request_decoder: RespRequestDecoder,
         command_service: CommandService,
         response_encoder: RespResponseEncoder,
+        metrics: Metrics,
         logger: Logger | None = None,
         read_size: int = 4096,
     ) -> None:
@@ -20,6 +22,7 @@ class SessionHandler:
         self._request_decoder = request_decoder
         self._command_service = command_service
         self._response_encoder = response_encoder
+        self._metrics = metrics
         self._logger = logger or Logger()
         self._read_size = read_size
 
@@ -29,9 +32,11 @@ class SessionHandler:
             if not request_bytes:
                 return
 
+            self._metrics.increment_requests()
             response = self._process_request(request_bytes)
             self._write_response(response)
         except Exception as error:
+            self._metrics.increment_errors()
             self._logger.error(f"session handling failed: {error}")
 
     def _read_request(self) -> bytes:


### PR DESCRIPTION
## 요약

- `Metrics`에 기본 카운터 메서드를 추가했습니다.
- `server.py`와 `session_handler.py`에 observability 호출 지점을 연결했습니다.
- 연결 수, 활성 연결 수, 요청 수, 오류 수를 기록할 수 있는 최소 구조를 만들었습니다.

## 범위

- `internal/observability/metrics.py`
- `internal/server/server.py`
- `internal/server/session_handler.py`

## 참고

- 현재는 내부 카운터 기반의 최소 observability만 포함합니다.
- 외부 메트릭 연동, 로그 포맷 고도화는 포함하지 않았습니다.