### PR TITLE
[2-3] SET, GET, DEL 서비스 구현

### DIFF
--- a/internal/service/del_service.py
+++ b/internal/service/del_service.py
@@ -1,2 +1,26 @@
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.repository.store_repository import StoreRepository
+from internal.repository.ttl_repository import TtlRepository
+
+
 class DelService:
-    pass
+    def __init__(
+        self,
+        store_repository: StoreRepository,
+        ttl_repository: TtlRepository,
+        expiration_manager: ExpirationManager,
+    ) -> None:
+        self._store_repository = store_repository
+        self._ttl_repository = ttl_repository
+        self._expiration_manager = expiration_manager
+
+    def execute(self, key: str) -> int:
+        if self._expiration_manager.purge_if_expired(key):
+            return 0
+
+        deleted = self._store_repository.delete(key)
+        if not deleted:
+            return 0
+
+        self._ttl_repository.delete_expiration(key)
+        return 1

--- a/internal/service/get_service.py
+++ b/internal/service/get_service.py
@@ -1,2 +1,16 @@
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.repository.store_repository import StoreRepository
+
+
 class GetService:
-    pass
+    def __init__(
+        self,
+        store_repository: StoreRepository,
+        expiration_manager: ExpirationManager,
+    ) -> None:
+        self._store_repository = store_repository
+        self._expiration_manager = expiration_manager
+
+    def execute(self, key: str) -> str | None:
+        self._expiration_manager.purge_if_expired(key)
+        return self._store_repository.get(key)

--- a/internal/service/set_service.py
+++ b/internal/service/set_service.py
@@ -1,2 +1,18 @@
+from internal.protocol.resp.messages import RESP_OK
+from internal.repository.store_repository import StoreRepository
+from internal.repository.ttl_repository import TtlRepository
+
+
 class SetService:
-    pass
+    def __init__(
+        self,
+        store_repository: StoreRepository,
+        ttl_repository: TtlRepository,
+    ) -> None:
+        self._store_repository = store_repository
+        self._ttl_repository = ttl_repository
+
+    def execute(self, key: str, value: str) -> str:
+        self._store_repository.set(key, value)
+        self._ttl_repository.delete_expiration(key)
+        return RESP_OK


### PR DESCRIPTION
## 작업 내용
- `SetService`, `GetService`, `DelService`를 구현했습니다.
- 저장소 계층과 `ExpirationManager`를 조합해 기본 문자열 명령의 서비스 로직을 추가했습니다.
- 각 서비스가 문서에 정의된 `SET`, `GET`, `DEL` 동작 규칙을 따르도록 정리했습니다.

## 변경 파일
- `internal/service/set_service.py`
- `internal/service/get_service.py`
- `internal/service/del_service.py`

## 반영 사항
- `SET` 실행 시 값 저장 후 기존 TTL 제거
- `GET` 실행 전 만료 여부 확인 후 값 또는 `None` 반환
- `DEL` 실행 전 만료 여부 확인 후 삭제 결과 `1` 또는 `0` 반환
- 서비스 계층이 protocol/server 계층에 직접 의존하지 않도록 구성

## 검증
- `python3 -m py_compile internal/service/set_service.py internal/service/get_service.py internal/service/del_service.py`

## 관련 이슈
- `[2-3] SET, GET, DEL 서비스 구현`
