### PR TITLE
[2-4] EXPIRE, TTL 서비스 및 CommandService 연결

### DIFF
--- a/internal/service/command_service.py
+++ b/internal/service/command_service.py
@@ -1,7 +1,88 @@
+from internal.clock.clock import Clock
 from internal.command.command import Command
+from internal.command.errors import CommandValidationError
 from internal.protocol.resp.types import RespValue
+from internal.repository.store_repository import StoreRepository
+from internal.repository.ttl_repository import TtlRepository
+from internal.service.del_service import DelService
+from internal.service.expire_service import ExpireService
+from internal.service.get_service import GetService
+from internal.service.set_service import SetService
+from internal.service.ttl_service import TtlService
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.expiration.ttl_calculator import TtlCalculator
 
 
 class CommandService:
+    def __init__(
+        self,
+        clock: Clock,
+        store_repository: StoreRepository,
+        ttl_repository: TtlRepository,
+    ) -> None:
+        ttl_calculator = TtlCalculator()
+        expiration_manager = ExpirationManager(
+            clock=clock,
+            ttl_calculator=ttl_calculator,
+            store_repository=store_repository,
+            ttl_repository=ttl_repository,
+        )
+        self._set_service = SetService(store_repository, ttl_repository)
+        self._get_service = GetService(store_repository, expiration_manager)
+        self._del_service = DelService(
+            store_repository,
+            ttl_repository,
+            expiration_manager,
+        )
+        self._expire_service = ExpireService(
+            clock,
+            ttl_calculator,
+            store_repository,
+            ttl_repository,
+            expiration_manager,
+        )
+        self._ttl_service = TtlService(
+            store_repository,
+            ttl_repository,
+            expiration_manager,
+        )
+
     def execute(self, command: Command) -> RespValue:
-        raise NotImplementedError("Command execution is not implemented yet")
+        if command.name == "SET":
+            return RespValue(
+                kind="simple_string",
+                value=self._set_service.execute(command.arguments[0], command.arguments[1]),
+            )
+        if command.name == "GET":
+            value = self._get_service.execute(command.arguments[0])
+            if value is None:
+                return RespValue(kind="null", value=None)
+            return RespValue(kind="blob_string", value=value)
+        if command.name == "DEL":
+            return RespValue(
+                kind="number",
+                value=self._del_service.execute(command.arguments[0]),
+            )
+        if command.name == "EXPIRE":
+            ttl_seconds = self._parse_expire_seconds(command.arguments[1])
+            return RespValue(
+                kind="number",
+                value=self._expire_service.execute(command.arguments[0], ttl_seconds),
+            )
+        if command.name == "TTL":
+            return RespValue(
+                kind="number",
+                value=self._ttl_service.execute(command.arguments[0]),
+            )
+        raise CommandValidationError("unsupported command")
+
+    def _parse_expire_seconds(self, value: str) -> int:
+        try:
+            ttl_seconds = int(value)
+        except ValueError as error:
+            raise CommandValidationError("invalid integer") from error
+
+        if ttl_seconds <= 0:
+            raise CommandValidationError("invalid ttl")
+
+        return ttl_seconds

--- a/internal/service/expire_service.py
+++ b/internal/service/expire_service.py
@@ -1,2 +1,35 @@
+from internal.clock.clock import Clock
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.expiration.ttl_calculator import TtlCalculator
+from internal.repository.store_repository import StoreRepository
+from internal.repository.ttl_repository import TtlRepository
+
+
 class ExpireService:
-    pass
+    def __init__(
+        self,
+        clock: Clock,
+        ttl_calculator: TtlCalculator,
+        store_repository: StoreRepository,
+        ttl_repository: TtlRepository,
+        expiration_manager: ExpirationManager,
+    ) -> None:
+        self._clock = clock
+        self._ttl_calculator = ttl_calculator
+        self._store_repository = store_repository
+        self._ttl_repository = ttl_repository
+        self._expiration_manager = expiration_manager
+
+    def execute(self, key: str, ttl_seconds: int) -> int:
+        if self._expiration_manager.purge_if_expired(key):
+            return 0
+
+        if self._store_repository.get(key) is None:
+            return 0
+
+        expires_at = self._ttl_calculator.calculate_expires_at(
+            self._clock.now(),
+            ttl_seconds,
+        )
+        self._ttl_repository.set_expiration(key, expires_at)
+        return 1

--- a/internal/service/ttl_service.py
+++ b/internal/service/ttl_service.py
@@ -1,2 +1,30 @@
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.repository.store_repository import StoreRepository
+from internal.repository.ttl_repository import TtlRepository
+
+
 class TtlService:
-    pass
+    def __init__(
+        self,
+        store_repository: StoreRepository,
+        ttl_repository: TtlRepository,
+        expiration_manager: ExpirationManager,
+    ) -> None:
+        self._store_repository = store_repository
+        self._ttl_repository = ttl_repository
+        self._expiration_manager = expiration_manager
+
+    def execute(self, key: str) -> int:
+        if self._expiration_manager.purge_if_expired(key):
+            return -2
+
+        if self._store_repository.get(key) is None:
+            return -2
+
+        if self._ttl_repository.get_expiration(key) is None:
+            return -1
+
+        remaining_seconds = self._expiration_manager.calculate_remaining_seconds(key)
+        if remaining_seconds is None:
+            return -1
+        return remaining_seconds


### PR DESCRIPTION
## 작업 내용
- `ExpireService`와 `TtlService`를 구현했습니다.
- `CommandService`에 `SET`, `GET`, `DEL`, `EXPIRE`, `TTL` 명령 분기를 연결했습니다.
- TTL 관련 서비스가 만료 처리 계층과 저장소 계층을 사용해 문서에 정의된 규칙대로 동작하도록 정리했습니다.

## 변경 파일
- `internal/service/expire_service.py`
- `internal/service/ttl_service.py`
- `internal/service/command_service.py`

## 반영 사항
- `EXPIRE` 실행 전 만료 상태를 먼저 정리하고, 유효한 키에만 TTL 설정
- `EXPIRE`에서 `seconds` 정수 파싱 및 `invalid integer`, `invalid ttl` 처리 추가
- `TTL`이 키 미존재 `-2`, TTL 없음 `-1`, 남은 TTL 정수 반환 규칙을 따르도록 구현
- `CommandService`에서 필수 5개 명령을 각 서비스로 분기하고 `RespValue`로 반환하도록 연결

## 검증
- `python3 -m py_compile internal/service/expire_service.py internal/service/ttl_service.py internal/service/command_service.py`

## 관련 이슈
- `[2-4] EXPIRE, TTL 서비스 및 CommandService 연결`
