### PR TITLE
feat: add graceful shutdown skeleton

### DIFF
--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -6,6 +6,7 @@ from internal.observability.metrics import Metrics
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.server.session_handler import SessionHandler
+from internal.server.shutdown import ShutdownManager
 from internal.service.command_service import CommandService
 
 
@@ -15,24 +16,37 @@ class MiniRedisServer:
         config: RuntimeConfig,
         logger: Logger | None = None,
         metrics: Metrics | None = None,
+        shutdown_manager: ShutdownManager | None = None,
     ) -> None:
         self._config = config
         self._logger = logger or Logger()
         self._metrics = metrics or Metrics()
+        self._shutdown_manager = shutdown_manager or ShutdownManager()
+        self._server_socket: socket.socket | None = None
 
     def run(self) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
+            self._server_socket = server_socket
             server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             server_socket.bind((self._config.host, self._config.port))
             server_socket.listen()
+            server_socket.settimeout(1.0)
 
             self._logger.info(
                 f"mini-redis server listening on {self._config.host}:{self._config.port}"
             )
 
             try:
-                while True:
-                    client_socket, client_address = server_socket.accept()
+                while not self._shutdown_manager.is_shutdown_requested():
+                    try:
+                        client_socket, client_address = server_socket.accept()
+                    except TimeoutError:
+                        continue
+                    except OSError:
+                        if self._shutdown_manager.is_shutdown_requested():
+                            break
+                        raise
+
                     with client_socket:
                         self._metrics.increment_connections()
                         self._metrics.increment_active_connections()
@@ -53,4 +67,16 @@ class MiniRedisServer:
                         finally:
                             self._metrics.decrement_active_connections()
             except KeyboardInterrupt:
+                self.stop()
+            finally:
+                self._server_socket = None
                 self._logger.info("mini-redis server stopped")
+
+    def stop(self) -> None:
+        if self._shutdown_manager.is_shutdown_requested():
+            return
+
+        self._logger.info("graceful shutdown requested")
+        self._shutdown_manager.request_shutdown()
+        if self._server_socket is not None:
+            self._server_socket.close()

--- a/internal/server/shutdown.py
+++ b/internal/server/shutdown.py
@@ -1,3 +1,9 @@
 class ShutdownManager:
-    def shutdown(self) -> None:
-        raise NotImplementedError("Graceful shutdown is not implemented yet")
+    def __init__(self) -> None:
+        self._shutdown_requested = False
+
+    def request_shutdown(self) -> None:
+        self._shutdown_requested = True
+
+    def is_shutdown_requested(self) -> bool:
+        return self._shutdown_requested


### PR DESCRIPTION
## 요약

- `ShutdownManager`를 구현해 종료 요청 상태를 관리하도록 했습니다.
- 서버 루프가 종료 요청을 감지하면 새 연결 수락을 중단하도록 변경했습니다.
- `KeyboardInterrupt`가 graceful shutdown 경로를 타도록 정리했습니다.

## 범위

- `internal/server/shutdown.py`
- `internal/server/server.py`

## 테스트

- `python -m pytest -q`
- 결과: `22 passed`