### PR TITLE
feat: reapply resource guard integration

### DIFF
--- a/internal/guard/resource_guard.py
+++ b/internal/guard/resource_guard.py
@@ -6,4 +6,10 @@ class ResourceGuard:
         self._limits = limits
 
     def validate_request_size(self, size_bytes: int) -> bool:
+        return self.is_request_size_allowed(size_bytes)
+
+    def is_request_size_allowed(self, size_bytes: int) -> bool:
         return size_bytes <= self._limits.max_request_size_bytes
+
+    def is_connection_allowed(self, active_connections: int) -> bool:
+        return active_connections < self._limits.max_connections

--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -1,10 +1,15 @@
 import socket
 
+from internal.clock.system_clock import SystemClock
 from internal.config.runtime_config import RuntimeConfig
+from internal.guard.limits import ResourceLimits
+from internal.guard.resource_guard import ResourceGuard
 from internal.observability.logger import Logger
 from internal.observability.metrics import Metrics
 from internal.protocol.resp.request_decoder import RespRequestDecoder
 from internal.protocol.resp.response_encoder import RespResponseEncoder
+from internal.repository.in_memory_store import InMemoryStoreRepository
+from internal.repository.in_memory_ttl import InMemoryTtlRepository
 from internal.server.session_handler import SessionHandler
 from internal.server.shutdown import ShutdownManager
 from internal.service.command_service import CommandService
@@ -23,6 +28,22 @@ class MiniRedisServer:
         self._metrics = metrics or Metrics()
         self._shutdown_manager = shutdown_manager or ShutdownManager()
         self._server_socket: socket.socket | None = None
+        self._clock = SystemClock()
+        self._store_repository = InMemoryStoreRepository()
+        self._ttl_repository = InMemoryTtlRepository()
+        self._resource_limits = ResourceLimits(
+            max_connections=self._config.max_connections,
+            max_request_size_bytes=self._config.max_request_size_bytes,
+            max_array_items=self._config.max_array_items,
+            max_resp_depth=self._config.max_resp_depth,
+            max_blob_size_bytes=self._config.max_blob_size_bytes,
+        )
+        self._resource_guard = ResourceGuard(self._resource_limits)
+        self._command_service = CommandService(
+            clock=self._clock,
+            store_repository=self._store_repository,
+            ttl_repository=self._ttl_repository,
+        )
 
     def run(self) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server_socket:
@@ -48,6 +69,13 @@ class MiniRedisServer:
                         raise
 
                     with client_socket:
+                        if not self._resource_guard.is_connection_allowed(
+                            self._metrics.active_connections
+                        ):
+                            self._metrics.increment_errors()
+                            self._logger.error("connection limit exceeded")
+                            continue
+
                         self._metrics.increment_connections()
                         self._metrics.increment_active_connections()
                         self._logger.info(
@@ -56,8 +84,9 @@ class MiniRedisServer:
                         handler = SessionHandler(
                             client_socket=client_socket,
                             request_decoder=RespRequestDecoder(),
-                            command_service=CommandService(),
+                            command_service=self._command_service,
                             response_encoder=RespResponseEncoder(),
+                            resource_guard=self._resource_guard,
                             metrics=self._metrics,
                             logger=self._logger,
                             read_size=self._config.max_request_size_bytes,

--- a/internal/server/session_handler.py
+++ b/internal/server/session_handler.py
@@ -1,5 +1,6 @@
 import socket
 
+from internal.guard.resource_guard import ResourceGuard
 from internal.observability.logger import Logger
 from internal.observability.metrics import Metrics
 from internal.protocol.resp.request_decoder import RespRequestDecoder
@@ -14,6 +15,7 @@ class SessionHandler:
         request_decoder: RespRequestDecoder,
         command_service: CommandService,
         response_encoder: RespResponseEncoder,
+        resource_guard: ResourceGuard,
         metrics: Metrics,
         logger: Logger | None = None,
         read_size: int = 4096,
@@ -22,6 +24,7 @@ class SessionHandler:
         self._request_decoder = request_decoder
         self._command_service = command_service
         self._response_encoder = response_encoder
+        self._resource_guard = resource_guard
         self._metrics = metrics
         self._logger = logger or Logger()
         self._read_size = read_size
@@ -30,6 +33,10 @@ class SessionHandler:
         try:
             request_bytes = self._read_request()
             if not request_bytes:
+                return
+            if not self._resource_guard.is_request_size_allowed(len(request_bytes)):
+                self._metrics.increment_errors()
+                self._logger.error("request size limit exceeded")
                 return
 
             self._metrics.increment_requests()


### PR DESCRIPTION
## 요약

- 최신 `dev`에서 빠져 있던 resource guard 통합을 다시 적용했습니다.
- `ResourceGuard`에 연결 수/요청 크기 제한 메서드를 추가했습니다.
- `server.py`, `session_handler.py`에 guard 호출 지점을 다시 연결했습니다.

## 테스트

- `python -m pytest -q`
- 결과: `26 passed`

## 참고

- 과거 브랜치를 그대로 재사용하지 않고, 현재 `dev` 구조에 맞춰 작은 범위로 재적용한 PR입니다.