### PR TITLE
feat: 서비스 응답을 RESP 타입 계약에 맞게 정리

### DIFF
--- a/internal/service/command_service.py
+++ b/internal/service/command_service.py
@@ -1,7 +1,20 @@
 from internal.clock.clock import Clock
 from internal.command.command import Command
 from internal.command.errors import CommandValidationError
-from internal.protocol.resp.types import RespValue
+from internal.expiration.expiration_manager import ExpirationManager
+from internal.expiration.ttl_calculator import TtlCalculator
+from internal.protocol.resp.messages import (
+    ERR_INVALID_INTEGER,
+    ERR_INVALID_TTL,
+    ERR_UNSUPPORTED_COMMAND,
+)
+from internal.protocol.resp.types import (
+    RespBlobString,
+    RespNull,
+    RespNumber,
+    RespSimpleString,
+    RespValue,
+)
 from internal.repository.store_repository import StoreRepository
 from internal.repository.ttl_repository import TtlRepository
 from internal.service.del_service import DelService
@@ -9,8 +22,6 @@ from internal.service.expire_service import ExpireService
 from internal.service.get_service import GetService
 from internal.service.set_service import SetService
 from internal.service.ttl_service import TtlService
-from internal.expiration.expiration_manager import ExpirationManager
-from internal.expiration.ttl_calculator import TtlCalculator
 
 
 class CommandService:
@@ -49,40 +60,36 @@ class CommandService:
 
     def execute(self, command: Command) -> RespValue:
         if command.name == "SET":
-            return RespValue(
-                kind="simple_string",
-                value=self._set_service.execute(command.arguments[0], command.arguments[1]),
+            return RespSimpleString(
+                value=self._set_service.execute(command.arguments[0], command.arguments[1])
             )
         if command.name == "GET":
             value = self._get_service.execute(command.arguments[0])
             if value is None:
-                return RespValue(kind="null", value=None)
-            return RespValue(kind="blob_string", value=value)
+                return RespNull()
+            return RespBlobString(value=value)
         if command.name == "DEL":
-            return RespValue(
-                kind="number",
+            return RespNumber(
                 value=self._del_service.execute(command.arguments[0]),
             )
         if command.name == "EXPIRE":
             ttl_seconds = self._parse_expire_seconds(command.arguments[1])
-            return RespValue(
-                kind="number",
+            return RespNumber(
                 value=self._expire_service.execute(command.arguments[0], ttl_seconds),
             )
         if command.name == "TTL":
-            return RespValue(
-                kind="number",
+            return RespNumber(
                 value=self._ttl_service.execute(command.arguments[0]),
             )
-        raise CommandValidationError("unsupported command")
+        raise CommandValidationError(ERR_UNSUPPORTED_COMMAND)
 
     def _parse_expire_seconds(self, value: str) -> int:
         try:
             ttl_seconds = int(value)
         except ValueError as error:
-            raise CommandValidationError("invalid integer") from error
+            raise CommandValidationError(ERR_INVALID_INTEGER) from error
 
         if ttl_seconds <= 0:
-            raise CommandValidationError("invalid ttl")
+            raise CommandValidationError(ERR_INVALID_TTL)
 
         return ttl_seconds

--- a/tests/test_command_service.py
+++ b/tests/test_command_service.py
@@ -1,0 +1,97 @@
+import pytest
+
+from internal.clock.fake_clock import FakeClock
+from internal.command.command import Command
+from internal.command.errors import CommandValidationError
+from internal.protocol.resp.messages import (
+    ERR_INVALID_INTEGER,
+    ERR_INVALID_TTL,
+    ERR_UNSUPPORTED_COMMAND,
+    RESP_OK,
+)
+from internal.protocol.resp.types import RespBlobString, RespNull, RespNumber, RespSimpleString
+from internal.repository.in_memory_store import InMemoryStoreRepository
+from internal.repository.in_memory_ttl import InMemoryTtlRepository
+from internal.service.command_service import CommandService
+
+
+def create_command_service() -> CommandService:
+    return CommandService(
+        clock=FakeClock(current_time=100.0),
+        store_repository=InMemoryStoreRepository(),
+        ttl_repository=InMemoryTtlRepository(),
+    )
+
+
+def test_execute_set_returns_simple_string() -> None:
+    service = create_command_service()
+
+    response = service.execute(Command(name="SET", arguments=("key", "value")))
+
+    assert response == RespSimpleString(value=RESP_OK)
+
+
+def test_execute_get_returns_blob_string_for_existing_key() -> None:
+    service = create_command_service()
+    service.execute(Command(name="SET", arguments=("key", "value")))
+
+    response = service.execute(Command(name="GET", arguments=("key",)))
+
+    assert response == RespBlobString(value="value")
+
+
+def test_execute_get_returns_null_for_missing_key() -> None:
+    service = create_command_service()
+
+    response = service.execute(Command(name="GET", arguments=("missing",)))
+
+    assert response == RespNull()
+
+
+def test_execute_del_returns_number() -> None:
+    service = create_command_service()
+    service.execute(Command(name="SET", arguments=("key", "value")))
+
+    response = service.execute(Command(name="DEL", arguments=("key",)))
+
+    assert response == RespNumber(value=1)
+
+
+def test_execute_expire_returns_number() -> None:
+    service = create_command_service()
+    service.execute(Command(name="SET", arguments=("key", "value")))
+
+    response = service.execute(Command(name="EXPIRE", arguments=("key", "10")))
+
+    assert response == RespNumber(value=1)
+
+
+def test_execute_ttl_returns_number() -> None:
+    service = create_command_service()
+    service.execute(Command(name="SET", arguments=("key", "value")))
+    service.execute(Command(name="EXPIRE", arguments=("key", "10")))
+
+    response = service.execute(Command(name="TTL", arguments=("key",)))
+
+    assert response == RespNumber(value=10)
+
+
+def test_execute_rejects_unsupported_command() -> None:
+    service = create_command_service()
+
+    with pytest.raises(CommandValidationError, match=ERR_UNSUPPORTED_COMMAND):
+        service.execute(Command(name="NOPE", arguments=()))
+
+
+def test_execute_rejects_non_integer_expire() -> None:
+    service = create_command_service()
+
+    with pytest.raises(CommandValidationError, match=ERR_INVALID_INTEGER):
+        service.execute(Command(name="EXPIRE", arguments=("key", "abc")))
+
+
+def test_execute_rejects_non_positive_expire() -> None:
+    service = create_command_service()
+
+    with pytest.raises(CommandValidationError, match=ERR_INVALID_TTL):
+        service.execute(Command(name="EXPIRE", arguments=("key", "0")))


### PR DESCRIPTION
## 관련 이슈
- closes #30

## 작업 내용
- `CommandService.execute()` 가 더 이상 이전 `RespValue(kind=..., value=...)` 스타일을 사용하지 않도록 정리했습니다.
- `SET` 은 `RespSimpleString`, `GET` 은 `RespBlobString` 또는 `RespNull`, `DEL`/`EXPIRE`/`TTL` 은 `RespNumber` 를 반환하도록 맞췄습니다.
- 서비스 계층 에러 메시지를 프로토콜 메시지 상수와 맞췄습니다.
- `tests/test_command_service.py` 를 추가해 서비스-프로토콜 경계의 응답 계약을 고정했습니다.

## 검증
- `.venv/bin/python -m pytest tests/test_command_service.py tests/test_command_parser.py tests/test_command_validator.py tests/test_request_decoder.py tests/test_response_encoder.py tests/test_hello_handler.py tests/test_protocol_handler.py -q`
- 결과: `34 passed`
- `python3 -m compileall internal tests`
- 수동 스모크 체크: `service-resp-smoke-ok`

## 공유할 포인트
- 이제 `CommandService` 반환값은 최신 RESP 타입 객체 기준으로 일관됩니다.
- 담당자 3이 `session_handler.py` 통합 시 응답 인코딩 경로를 그대로 재사용할 수 있습니다.