### PR TITLE
feat: integrate session flow with protocol handler

### DIFF
--- a/internal/server/server.py
+++ b/internal/server/server.py
@@ -6,7 +6,7 @@ from internal.guard.limits import ResourceLimits
 from internal.guard.resource_guard import ResourceGuard
 from internal.observability.logger import Logger
 from internal.observability.metrics import Metrics
-from internal.protocol.resp.request_decoder import RespRequestDecoder
+from internal.protocol.resp.protocol_handler import ProtocolHandler
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.repository.in_memory_store import InMemoryStoreRepository
 from internal.repository.in_memory_ttl import InMemoryTtlRepository
@@ -83,7 +83,7 @@ class MiniRedisServer:
                         )
                         handler = SessionHandler(
                             client_socket=client_socket,
-                            request_decoder=RespRequestDecoder(),
+                            protocol_handler=ProtocolHandler(),
                             command_service=self._command_service,
                             response_encoder=RespResponseEncoder(),
                             resource_guard=self._resource_guard,

--- a/internal/server/session_handler.py
+++ b/internal/server/session_handler.py
@@ -3,7 +3,7 @@ import socket
 from internal.guard.resource_guard import ResourceGuard
 from internal.observability.logger import Logger
 from internal.observability.metrics import Metrics
-from internal.protocol.resp.request_decoder import RespRequestDecoder
+from internal.protocol.resp.protocol_handler import ProtocolHandler
 from internal.protocol.resp.response_encoder import RespResponseEncoder
 from internal.service.command_service import CommandService
 
@@ -12,7 +12,7 @@ class SessionHandler:
     def __init__(
         self,
         client_socket: socket.socket,
-        request_decoder: RespRequestDecoder,
+        protocol_handler: ProtocolHandler,
         command_service: CommandService,
         response_encoder: RespResponseEncoder,
         resource_guard: ResourceGuard,
@@ -21,7 +21,7 @@ class SessionHandler:
         read_size: int = 4096,
     ) -> None:
         self._client_socket = client_socket
-        self._request_decoder = request_decoder
+        self._protocol_handler = protocol_handler
         self._command_service = command_service
         self._response_encoder = response_encoder
         self._resource_guard = resource_guard
@@ -50,8 +50,14 @@ class SessionHandler:
         return self._client_socket.recv(self._read_size)
 
     def _process_request(self, request_bytes: bytes) -> bytes:
-        decoded_request = self._request_decoder.decode(request_bytes)
-        service_result = self._command_service.execute(decoded_request)  # type: ignore[arg-type]
+        protocol_result = self._protocol_handler.handle_with_error_response(request_bytes)
+        if protocol_result.has_immediate_response():
+            return self._response_encoder.encode(protocol_result.response)
+
+        if protocol_result.command is None:
+            raise ValueError("protocol handler returned neither command nor response")
+
+        service_result = self._command_service.execute(protocol_result.command)
         return self._response_encoder.encode(service_result)
 
     def _write_response(self, response: bytes) -> None:


### PR DESCRIPTION
## 요약

- `SessionHandler`가 `ProtocolHandler`를 사용하도록 변경했습니다.
- `HELLO 3` 같은 즉시 응답 요청과 일반 명령 요청을 세션 단위에서 분기하도록 정리했습니다.
- 일반 명령은 `CommandService.execute()`로 전달하고, 최종 응답은 `RespResponseEncoder`로 인코딩하도록 연결했습니다.
- 서버에서 `SessionHandler` 생성 시 `ProtocolHandler`를 주입하도록 변경했습니다.

## 작업 목적

- 현재 서버 요청 처리 경로를 최신 `dev` 구조에 맞춰 `ProtocolHandler -> CommandService -> RespResponseEncoder` 흐름으로 정리하기 위함입니다.
- 기존에는 `RespRequestDecoder.decode()` 결과를 바로 `CommandService.execute()`에 전달하고 있어, 실제 명령 처리 시그니처와 맞지 않는 문제가 있었습니다.

## 포함 범위

- 포함:
  - `internal/server/session_handler.py`
  - `internal/server/server.py`

- 제외:
  - `ProtocolHandler` 내부 로직 변경
  - observability 추가 개선
  - graceful shutdown 보강
  - server integration test 추가

## 구현 내용

- `SessionHandler`
  - `RespRequestDecoder` 대신 `ProtocolHandler` 주입
  - `handle_with_error_response()` 사용
  - 즉시 응답이 있으면 바로 인코딩 후 반환
  - 일반 명령이면 `CommandService.execute()` 호출 후 응답 인코딩

- `MiniRedisServer`
  - `SessionHandler` 생성 시 `ProtocolHandler()` 주입

## 테스트

- `python -m pytest -q`
- 결과: `36 passed`

## 참고

- 이번 변경으로 서버 요청 처리 경로가 현재 프로토콜/서비스 계층 구조와 맞춰졌습니다.
- 다음 단계에서는 server/session integration test를 추가하는 것이 자연스럽습니다.
